### PR TITLE
[Proposal] add sbt-coursier

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.4")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1")


### PR DESCRIPTION
Hi, I'm facing unresolved dependencies with unknown error but sbt-coursier (https://github.com/coursier/coursier) works well. 
So this is proposal P/R and how do you feel?

```
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: net.jcip#jcip-annotations;1.0: net.jcip#jcip-annotations;1.0!jcip-annotations.pom(pom.original) origin location must be absolute: file:/Users/smdmts/.m2/repository/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.pom
[warn]  :: net.minidev#json-smart;1.1.1: net.minidev#json-smart;1.1.1!json-smart.pom(pom.original) origin location must be absolute: file:/Users/smdmts/.m2/repository/net/minidev/json-smart/1.1.1/json-smart-1.1.1.pom
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]          net.jcip:jcip-annotations:1.0 (/Users/smdmts/git/oss/spark-bigquery/build.sbt#L30-46)
[warn]            +- com.nimbusds:nimbus-jose-jwt:3.9
[warn]            +- org.apache.hadoop:hadoop-auth:2.8.1
[warn]            +- org.apache.hadoop:hadoop-common:2.8.1
[warn]            +- org.apache.hadoop:hadoop-client:2.8.1
[warn]            +- com.holdenkarau:spark-testing-base_2.11:2.2.0_0.8.0 (/Users/smdmts/git/oss/spark-bigquery/build.sbt#L30-46)
[warn]            +- com.github.samelamin:spark-bigquery_2.11:0.2.4
[warn]          net.minidev:json-smart:1.1.1 (/Users/smdmts/git/oss/spark-bigquery/build.sbt#L30-46)
[warn]            +- com.nimbusds:nimbus-jose-jwt:3.9
[warn]            +- org.apache.hadoop:hadoop-auth:2.8.1
[warn]            +- org.apache.hadoop:hadoop-common:2.8.1
[warn]            +- org.apache.hadoop:hadoop-client:2.8.1
[warn]            +- com.holdenkarau:spark-testing-base_2.11:2.2.0_0.8.0 (/Users/smdmts/git/oss/spark-bigquery/build.sbt#L30-46)
[warn]            +- com.github.samelamin:spark-bigquery_2.11:0.2.4
```