### PR TITLE
Allow more BigQuery zones

### DIFF
--- a/src/main/scala/com/samelamin/spark/bigquery/BigQueryClient.scala
+++ b/src/main/scala/com/samelamin/spark/bigquery/BigQueryClient.scala
@@ -158,7 +158,7 @@ class BigQueryClient(sqlContext: SQLContext, var bigquery: Bigquery = null) exte
   private def stagingDataset(location: String): DatasetReference = {
     // Create staging dataset if it does not already exist
     val prefix = hadoopConfiguration.get(STAGING_DATASET_PREFIX, STAGING_DATASET_PREFIX_DEFAULT)
-    val datasetId = prefix + location.toLowerCase
+    val datasetId = prefix + location.replace("-", "_").toLowerCase
     try {
       bigquery.datasets().get(projectId, datasetId).execute()
       logger.info(s"Staging dataset $projectId:$datasetId already exists")


### PR DESCRIPTION
When using zones like `asia-east1`, `asia-southeast1`, etc, the code will throw error on this line of code. Need to replace `-` part of the location to `_` so that the location can be used to form a dataset ID.